### PR TITLE
Move default knob values into constants

### DIFF
--- a/limitlion/__init__.py
+++ b/limitlion/__init__.py
@@ -9,4 +9,7 @@ __all__ = ['throttle',
            'throttle_reset',
            'throttle_set',
            'throttle_wait',
+           'THROTTLE_BURST_DEFAULT',
+           'THROTTLE_WINDOW_DEFAULT',
+           'THROTTLE_REQUESTED_TOKENS_DEFAULT',
            ]

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -6,6 +6,11 @@ import pkg_resources
 
 KEY_FORMAT = 'throttle:{}'
 
+# throttle knob defaults
+THROTTLE_BURST_DEFAULT = 1
+THROTTLE_WINDOW_DEFAULT = 5
+THROTTLE_REQUESTED_TOKENS_DEFAULT = 1
+
 throttle_script = None
 redis = None
 
@@ -25,7 +30,13 @@ def _verify_configured():
         raise RuntimeError('Throttle is not configured')
 
 
-def throttle(name, rps, burst=1, window=5, requested_tokens=1):
+def throttle(
+    name,
+    rps,
+    burst=THROTTLE_BURST_DEFAULT,
+    window=THROTTLE_WINDOW_DEFAULT,
+    requested_tokens=THROTTLE_REQUESTED_TOKENS_DEFAULT,
+):
     """
     Throttle that allows orchestration of distributed workers.
 


### PR DESCRIPTION
This change moves the default knob value kwargs into constants.

The primary motivation for this change is to be able to determine default knob values in case they're not overridden in Redis. `throttle` only requires an `rps` default, so if the others kwargs aren't overridden then it's hard to figure out the default knob values.