### PR TITLE
Add check for value errors when setting throttle params

### DIFF
--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -157,6 +157,14 @@ def throttle_set(name, rps=None, burst=None, window=None):
     set_values_pipe = redis.pipeline()
     for param, param_name in params:
         if param is not None:
+            # Throttle values can only be positive floats
+            try:
+                assert float(param) >= 0
+            except (ValueError, AssertionError):
+                raise ValueError(
+                    '"{}" is not a valid throttle value. Throttle values must '
+                    'be positive floats.'.format(param)
+                )
             set_values_pipe.hset(key, param_name, param)
 
     set_values_pipe.execute()

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -18,7 +18,16 @@ redis = None
 def _validate_throttle(key, params):
     check_values_pipe = redis.pipeline()
     for param, param_name in params:
-        if param is None:
+        if param is not None:
+            # Throttle values can only be positive floats
+            try:
+                assert float(param) >= 0
+            except (ValueError, AssertionError):
+                raise ValueError(
+                    '"{}" is not a valid throttle value. Throttle values must '
+                    'be positive floats.'.format(param)
+                )
+        else:
             check_values_pipe.hexists(key, param_name)
     if not all(check_values_pipe.execute()):
         raise IndexError(
@@ -157,14 +166,6 @@ def throttle_set(name, rps=None, burst=None, window=None):
     set_values_pipe = redis.pipeline()
     for param, param_name in params:
         if param is not None:
-            # Throttle values can only be positive floats
-            try:
-                assert float(param) >= 0
-            except (ValueError, AssertionError):
-                raise ValueError(
-                    '"{}" is not a valid throttle value. Throttle values must '
-                    'be positive floats.'.format(param)
-                )
             set_values_pipe.hset(key, param_name, param)
 
     set_values_pipe.execute()

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -281,6 +281,24 @@ class TestThrottle:
         assert allowed is True
         assert tokens == 99
 
+    @pytest.mark.parametrize('value', ['a', -100, '-100'])
+    def test_setting_invalid_throttle_values(self, value):
+        """Tests setting throttle values that are not
+        positive floats.
+        """
+        throttle_name = 'test'
+
+        start_time = int(time.time())
+
+        self._freeze_redis_time(start_time, 0)
+
+        with pytest.raises(ValueError) as excinfo:
+            limitlion.throttle_set(throttle_name, value, 2, 6)
+        assert (
+            '"{}" is not a valid throttle value. Throttle values must '
+            'be positive floats.'.format(value)
+        ) in str(excinfo.value)
+
     def test_get_throttle(self):
         """Test getting throttle settings."""
 


### PR DESCRIPTION
Fixes #17 

This PR adds a check that values sent to `throttle_set` are positive floats. If not, we raise a ValueError. 

This adds a test to confirm that as well. 