### PR TITLE
Add knobs TTL and max_wait to throttle_wait

### DIFF
--- a/limitlion/throttle.lua
+++ b/limitlion/throttle.lua
@@ -100,6 +100,7 @@ local default_rps = ARGV[2]
 local default_burst = ARGV[3]
 local default_window = ARGV[4]
 local requested_tokens = tonumber(ARGV[5])
+local update_knobs_ttl = tonumber(ARGV[6])
 local rps
 local burst
 local window
@@ -120,7 +121,9 @@ else
   burst = tonumber(knobs[2])
   window = tonumber(knobs[3])
   -- Expire knobs hash 7 days after last time used
-  redis.call("EXPIRE", knobs_key, 604800)
+  if update_knobs_ttl == 1 then
+    redis.call("EXPIRE", knobs_key, 604800)
+  end
 end
 
 -- Use redis server time so it is consistent across callers

--- a/limitlion/throttle.lua
+++ b/limitlion/throttle.lua
@@ -100,7 +100,7 @@ local default_rps = ARGV[2]
 local default_burst = ARGV[3]
 local default_window = ARGV[4]
 local requested_tokens = tonumber(ARGV[5])
-local update_knobs_ttl = tonumber(ARGV[6])
+local knobs_ttl = tonumber(ARGV[6])
 local rps
 local burst
 local window
@@ -121,8 +121,8 @@ else
   burst = tonumber(knobs[2])
   window = tonumber(knobs[3])
   -- Expire knobs hash 7 days after last time used
-  if update_knobs_ttl == 1 then
-    redis.call("EXPIRE", knobs_key, 604800)
+  if knobs_ttl > 0 then
+    redis.call("EXPIRE", knobs_key, knobs_ttl)
   end
 end
 

--- a/limitlion/throttle.lua
+++ b/limitlion/throttle.lua
@@ -1,7 +1,7 @@
 -- This script implements a per second token bucket rate limiting algorithm.  It is
 -- based on Stripe's published script.
 -- KEYS = {}  ARGV = { throttle knob name, default rate (rps), default burst multiplier,
---                     default rate limit window in seconds, requested tokens }
+--                     default rate limit window in seconds, requested tokens, knobs_ttl }
 -- Returns: allowed (1=allowed, 0=not allowed),
 --          tokens left,
 --          decimal seconds left in this window
@@ -120,7 +120,7 @@ else
   rps = tonumber(knobs[1])
   burst = tonumber(knobs[2])
   window = tonumber(knobs[3])
-  -- Expire knobs hash 7 days after last time used
+  -- Set knobs hash expiration if knobs_ttl is specified
   if knobs_ttl > 0 then
     redis.call("EXPIRE", knobs_key, knobs_ttl)
   end

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -184,7 +184,7 @@ def throttle_set(name, rps=None, burst=None, window=None, knobs_ttl=None):
     set_values_pipe.execute()
 
 
-def throttle_wait(name, *args, max_wait=None, **kwargs):
+def throttle_wait(name, *args, **kwargs):
     """Sleeps time specified by throttle if needed.
 
     This will wait potentially forever to get permission to do work
@@ -196,19 +196,17 @@ def throttle_wait(name, *args, max_wait=None, **kwargs):
         do_work()
     """
 
+    max_wait = kwargs.pop('max_wait', None)
+
     def throttle_func():
         start_time = time.time()
-        allowed, tokens, sleep = throttle(
-            name, *args, **kwargs
-        )
+        allowed, tokens, sleep = throttle(name, *args, **kwargs)
         while not allowed:
             if max_wait is not None and time.time() - start_time > max_wait:
                 return False
 
             time.sleep(sleep)
-            allowed, tokens, sleep = throttle(
-                name, *args, **kwargs
-            )
+            allowed, tokens, sleep = throttle(name, *args, **kwargs)
         return True
 
     return throttle_func

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -196,14 +196,21 @@ def throttle_wait(name, *args, **kwargs):
         do_work()
     """
 
+    max_wait = kwargs.pop('max_wait', None)
+
     def throttle_func(requested_tokens=1):
+        start_time = time.time()
         allowed, tokens, sleep = throttle(
             name, *args, requested_tokens=requested_tokens, **kwargs
         )
         while not allowed:
+            if max_wait is not None and time.time() - start_time > max_wait:
+                return False
+
             time.sleep(sleep)
             allowed, tokens, sleep = throttle(
                 name, *args, requested_tokens=requested_tokens, **kwargs
             )
+        return True
 
     return throttle_func

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -208,10 +208,9 @@ def throttle_wait(name, *args, **kwargs):
         allowed, tokens, sleep = throttle(name, *args, **kwargs)
         while not allowed:
             if max_wait is not None and time.time() - start_time > max_wait:
-                return False
-
+                break
             time.sleep(sleep)
             allowed, tokens, sleep = throttle(name, *args, **kwargs)
-        return True
+        return allowed, tokens, sleep
 
     return throttle_func

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -206,14 +206,18 @@ def throttle_wait(name, *args, **kwargs):
 
     max_wait = kwargs.pop('max_wait', None)
 
-    def throttle_func():
+    def throttle_func(requested_tokens=1):
         start_time = time.time()
-        allowed, tokens, sleep = throttle(name, *args, **kwargs)
+        allowed, tokens, sleep = throttle(
+            name, *args, requested_tokens=requested_tokens, **kwargs
+        )
         while not allowed:
             if max_wait is not None and time.time() - start_time > max_wait:
                 break
             time.sleep(sleep)
-            allowed, tokens, sleep = throttle(name, *args, **kwargs)
+            allowed, tokens, sleep = throttle(
+                name, *args, requested_tokens=requested_tokens, **kwargs
+            )
         return allowed, tokens, sleep
 
     return throttle_func

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -168,7 +168,12 @@ def throttle_reset(name):
 
 
 def throttle_set(name, rps=None, burst=None, window=None, knobs_ttl=None):
-    """Adjust throttle values in redis."""
+    """
+    Adjust throttle values in redis.
+
+    If knobs_ttl is used here the throttle() call needs to be called
+    with knobs_ttl=0 so the ttl isn't also set in the Lua script
+    """
 
     _verify_configured()
     key = KEY_FORMAT.format(name) + ':knobs'
@@ -181,8 +186,6 @@ def throttle_set(name, rps=None, burst=None, window=None, knobs_ttl=None):
         if param is not None:
             set_values_pipe.hset(key, param_name, param)
 
-    # throttle() needs to be called with knobs_ttl=0 so
-    # the ttl isn't set in the Lua script
     if knobs_ttl:
         set_values_pipe.expire(key, knobs_ttl)
 

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -184,7 +184,7 @@ def throttle_set(name, rps=None, burst=None, window=None, knobs_ttl=None):
     set_values_pipe.execute()
 
 
-def throttle_wait(name, *args, **kwargs):
+def throttle_wait(name, *args, max_wait=None, **kwargs):
     """Sleeps time specified by throttle if needed.
 
     This will wait potentially forever to get permission to do work
@@ -196,12 +196,10 @@ def throttle_wait(name, *args, **kwargs):
         do_work()
     """
 
-    max_wait = kwargs.pop('max_wait', None)
-
-    def throttle_func(requested_tokens=1):
+    def throttle_func():
         start_time = time.time()
         allowed, tokens, sleep = throttle(
-            name, *args, requested_tokens=requested_tokens, **kwargs
+            name, *args, **kwargs
         )
         while not allowed:
             if max_wait is not None and time.time() - start_time > max_wait:
@@ -209,7 +207,7 @@ def throttle_wait(name, *args, **kwargs):
 
             time.sleep(sleep)
             allowed, tokens, sleep = throttle(
-                name, *args, requested_tokens=requested_tokens, **kwargs
+                name, *args, **kwargs
             )
         return True
 

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -421,9 +421,16 @@ class TestThrottle:
     def test_throttle_wait(self):
         """Test wait helper method."""
 
-        throttle_func = limitlion.throttle_wait('test', rps=123)
+        throttle_name = 'test'
+        throttle_func = limitlion.throttle_wait(
+            throttle_name, rps=123, requested_tokens=2
+        )
         allowed = throttle_func()
+        tokens, refreshed, rps, burst, window = limitlion.throttle_get(
+            throttle_name
+        )
         assert allowed
+        assert int(tokens) == 613
 
     def test_throttle_wait_with_max_wait(self):
         """Test wait helper method."""

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -422,10 +422,8 @@ class TestThrottle:
         """Test wait helper method."""
 
         throttle_name = 'test'
-        throttle_func = limitlion.throttle_wait(
-            throttle_name, rps=123, requested_tokens=2
-        )
-        allowed, tokens, sleep = throttle_func()
+        throttle_func = limitlion.throttle_wait(throttle_name, rps=123)
+        allowed, tokens, sleep = throttle_func(requested_tokens=2)
 
         assert allowed is True
         assert int(tokens) == 613


### PR DESCRIPTION
* Add the ability to set throttle knobs and have them expire versus keep getting pushed out 7 days each time the throttle is used
* Add a max wait time to `throttle_wait()` so it doesn't always wait forever
* Fix `throttle_wait()`'s `requested_tokens` parameter to work properly in py2 and py3.