### PR TITLE
Refactor pkg_resources -> importlib

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools
         pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming isort
         pip install --no-deps -r requirements.txt
         pip install -r requirements_test.txt

--- a/limitlion/running_counter.py
+++ b/limitlion/running_counter.py
@@ -1,11 +1,12 @@
 import itertools
 import time
 from collections import namedtuple
-from distutils.version import LooseVersion
 from importlib.metadata import version
 
+from packaging.version import Version
+
 REDIS_PY_VERSION = version("redis")
-IS_REDIS_PY_2 = LooseVersion(REDIS_PY_VERSION) < LooseVersion("3")
+IS_REDIS_PY_2 = Version(REDIS_PY_VERSION) < Version("3")
 
 
 BucketCount = namedtuple('BucketCount', ['bucket', 'count'])

--- a/limitlion/running_counter.py
+++ b/limitlion/running_counter.py
@@ -3,9 +3,9 @@ import time
 from collections import namedtuple
 from distutils.version import LooseVersion
 
-import pkg_resources
+from importlib.metadata import version
 
-REDIS_PY_VERSION = pkg_resources.get_distribution("redis").version
+REDIS_PY_VERSION = version("redis")
 IS_REDIS_PY_2 = LooseVersion(REDIS_PY_VERSION) < LooseVersion("3")
 
 

--- a/limitlion/running_counter.py
+++ b/limitlion/running_counter.py
@@ -2,7 +2,6 @@ import itertools
 import time
 from collections import namedtuple
 from distutils.version import LooseVersion
-
 from importlib.metadata import version
 
 REDIS_PY_VERSION = version("redis")

--- a/limitlion/running_counter.py
+++ b/limitlion/running_counter.py
@@ -1,13 +1,6 @@
 import itertools
 import time
 from collections import namedtuple
-from importlib.metadata import version
-
-from packaging.version import Version
-
-REDIS_PY_VERSION = version("redis")
-IS_REDIS_PY_2 = Version(REDIS_PY_VERSION) < Version("3")
-
 
 BucketCount = namedtuple('BucketCount', ['bucket', 'count'])
 
@@ -204,10 +197,7 @@ class RunningCounter:
         pipeline.expire(bucket_key, expire)
         if self.group_name is not None:
             group_key = self._group_key()
-            if IS_REDIS_PY_2:
-                pipeline.zadd(group_key, name, now)
-            else:
-                pipeline.zadd(group_key, {name: now})
+            pipeline.zadd(group_key, {name: now})
             pipeline.expire(group_key, expire)
             # Trim zset to keys used within window so
             # it doesn't grow uncapped.

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -104,7 +104,9 @@ def throttle_configure(redis_instance, testing=False):
     global redis, throttle_script
     redis = redis_instance
 
-    lua_script = resources.files(__package__).joinpath('throttle.lua').read_text()
+    lua_script = (
+        resources.files(__package__).joinpath('throttle.lua').read_text()
+    )
 
     # Modify scripts when testing so time can be frozen
     if testing:

--- a/limitlion/throttle.py
+++ b/limitlion/throttle.py
@@ -1,8 +1,7 @@
 """Token bucket throttle backed by Redis."""
 
 import time
-
-import pkg_resources
+from importlib import resources
 
 KEY_FORMAT = 'throttle:{}'
 
@@ -105,9 +104,7 @@ def throttle_configure(redis_instance, testing=False):
     global redis, throttle_script
     redis = redis_instance
 
-    lua_script = pkg_resources.resource_string(
-        __name__, 'throttle.lua'
-    ).decode()
+    lua_script = resources.files(__package__).joinpath('throttle.lua').read_text()
 
     # Modify scripts when testing so time can be frozen
     if testing:

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     packages=[


### PR DESCRIPTION
Part of https://github.com/closeio/limitlion/issues/37

We still need to release a new version afterwards. I'll probably want to port to uv + ruff first though.

Note that I did actually just end up dropping support for Redis-py 2.x. It's very old at this point, I think 5 major versions behind and I don't think we have a good reason to continue supporting it.