### PR TITLE
Use Ruff + uv for dev tooling + package metadata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming isort
+        pip install ruff
         pip install --no-deps -r requirements.txt
         pip install -r requirements_test.txt
     
@@ -52,8 +52,8 @@ jobs:
     
     - name: Linting
       run: |
-        flake8
-        isort -rc -c .
+        ruff check .
+        ruff format --check .
         luacheck --max-cyclomatic-complexity 11 --globals redis ARGV KEYS -r limitlion
     
     - name: Run tests with coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       uses: astral-sh/setup-uv@v6
       with:
         enable-cache: true
-        cache-dependency-glob: "requirements*.txt"
+        cache-dependency-glob: "pyproject.toml"
     
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        enable-cache: true
+        cache-dependency-glob: "requirements*.txt"
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
     
     - name: Install system dependencies
       run: |
@@ -41,24 +45,21 @@ jobs:
     
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install ruff
-        pip install --no-deps -r requirements.txt
-        pip install -r requirements_test.txt
+        uv sync --extra test
     
     - name: Install specific Redis version
       run: |
-        pip install redis==${{ matrix.redis-client-version }}
+        uv pip install redis==${{ matrix.redis-client-version }}
     
     - name: Linting
       run: |
-        ruff check .
-        ruff format --check .
+        uv run ruff check .
+        uv run ruff format --check .
         luacheck --max-cyclomatic-complexity 11 --globals redis ARGV KEYS -r limitlion
     
     - name: Run tests with coverage
       run: |
-        PYTHONPATH=. pytest --cov=limitlion --cov-report=xml
+        uv run pytest --cov=limitlion --cov-report=xml
     
     - name: Upload coverage report
       uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,43 @@
+[project]
+name = "limitlion"
+version = "1.0.0"
+description = "Close LimitLion"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "redis>=4"
+]
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "coverage",
+    "pytest-cov",
+    "ruff",
+    "freezefrog>=0.4.1"
+]
+
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["limitlion*"]
+
+[tool.setuptools.package-data]
+limitlion = ["*.lua"]
+
 [tool.ruff]
 line-length = 79
 exclude = [".git", ".venv", "ui"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ test = [
 ]
 
 [build-system]
-requires = ["setuptools>=45", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.packages.find]
-include = ["limitlion*"]
+[tool.setuptools]
+include-package-data = true
 
 [tool.setuptools.package-data]
 limitlion = ["*.lua"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,35 @@
-[tool.black]
-skip-string-normalization = true
+[tool.ruff]
 line-length = 79
-exclude = '''
-/(
-    \.git
-  | \.venv
-  | ui
-)/
-'''
+exclude = [".git", ".venv", "ui"]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "N",   # pep8-naming
+    "C90", # mccabe complexity
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+    "F403",  # star imports
+    "F405",  # undefined names from star imports
+    "N806",  # variable should be lowercase
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 12
+
+[tool.ruff.lint.isort]
+known-first-party = ["limitlion"]
+known-third-party = []
+section-order = ["future", "standard-library", "third-party", "first-party", "tests", "local-folder"]
+split-on-trailing-comma = false
+
+[tool.ruff.lint.isort.sections]
+tests = ["tests"]
+
+[tool.ruff.format]
+quote-style = "single"
+skip-magic-trailing-comma = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-redis==3.5.3
-freezefrog==0.4.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,0 @@
- pytest
- coverage
- pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,3 @@
 [tool:pytest]
 testpaths=tests
 
-[flake8]
-exclude=build,dist,docs,sql_migrations,venv,.tox,.eggs,venv3
-ignore=D1,D200,D202,D204,D205,D40,D413,E127,E128,E226,F403,F405,I100,N806
-import-order-style=google
-max-complexity=12
-max-line-length = 80
-
-[isort]
-skip=.tox,venv,venv3
-not_skip=
-  __init__.py
-known_first_party = limitlion
-known_tests=tests
-sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER
-default_section=THIRDPARTY
-use_parentheses=true
-multi_line_output=5

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-"""LimitLion setup."""
-
-from setuptools import setup
-
-# All metadata is now in pyproject.toml
-setup()

--- a/setup.py
+++ b/setup.py
@@ -2,34 +2,5 @@
 
 from setuptools import setup
 
-install_requires = ['redis>=2']
-
-tests_require = install_requires + ['pytest', 'pytest-cov']
-
-with open('README.md', 'r') as fh:
-    long_description = fh.read()
-
-setup(
-    name='limitlion',
-    version='1.0.0',
-    url='http://github.com/closeio/limitlion',
-    description='Close LimitLion',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    platforms='any',
-    classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
-    packages=['limitlion'],
-    package_data={'limitlion': ['*.lua']},
-    install_requires=install_requires,
-    tests_require=tests_require,
-)
+# All metadata is now in pyproject.toml
+setup()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = ['redis>=2']
 
 tests_require = install_requires + ['pytest', 'pytest-cov']
 
-with open("README.md", "r") as fh:
+with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setup(
@@ -15,7 +15,7 @@ setup(
     url='http://github.com/closeio/limitlion',
     description='Close LimitLion',
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type='text/markdown',
     platforms='any',
     classifiers=[
         'Intended Audience :: Developers',
@@ -28,9 +28,7 @@ setup(
         'Programming Language :: Python :: 3.13',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    packages=[
-        'limitlion',
-    ],
+    packages=['limitlion'],
     package_data={'limitlion': ['*.lua']},
     install_requires=install_requires,
     tests_require=tests_require,

--- a/tests/test_running_counter.py
+++ b/tests/test_running_counter.py
@@ -1,4 +1,5 @@
 """LimitLion tests."""
+
 import datetime
 import time
 
@@ -17,12 +18,7 @@ class TestRunningCounter:
         # Start counter now
         now = start = datetime.datetime.utcnow().replace(second=0, minute=0)
         with FreezeTime(now):
-            counter = RunningCounter(
-                redis,
-                interval,
-                num_buckets,
-                name,
-            )
+            counter = RunningCounter(redis, interval, num_buckets, name)
             # Add two values to current bucket
             counter.inc(1)
             counter.inc(1.2)
@@ -167,11 +163,11 @@ class TestRunningCounter:
 
     def test_delete_group_counter(self, redis):
         counter = RunningCounter(redis, 1, 1, group_name='group')
-        counter.inc(name="name1")
-        counter.delete(name="name1")
+        counter.inc(name='name1')
+        counter.delete(name='name1')
         assert counter.group_counts() == {}
-        counter.inc(name="name1")
-        counter.inc(name="name2")
+        counter.inc(name='name1')
+        counter.inc(name='name2')
         counter.delete_group()
         assert counter.group_counts() == {}
 
@@ -235,10 +231,7 @@ class TestRunningCounter:
                 'counter1': 2.0,
                 'counter2': 6.0,
             }
-            assert counter.group_counts() == {
-                'counter1': 3.0,
-                'counter2': 9.0,
-            }
+            assert counter.group_counts() == {'counter1': 3.0, 'counter2': 9.0}
             assert counter.group_counts(recent_buckets=10) == {
                 'counter1': 3.0,
                 'counter2': 9.0,


### PR DESCRIPTION
This PR:
* replaces black/isort/flake8 with ruff (I set the settings so that only two files needed to be reformatted instead of reformatting everything)
* migrates dependency management to `uv`
* migrates project metadata into `pyproject.toml` (supporting migrating to `uv`)

Ref https://github.com/closeio/limitlion/issues/37