### PR TITLE
Bump Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 1.1.0
+
+* Dropped support for EOL python versions (3.8 and below)
+* Dropped support for `redis` (the python client) 2 and 3 (tested versions are
+  4.x-7.x)
+* refacatored to not rely on `pkg_resources`
+
 ## Version 1.0.0
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,6 @@ tests = ["tests"]
 [tool.ruff.format]
 quote-style = "single"
 skip-magic-trailing-comma = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "limitlion"
-version = "1.0.0"
+version = "1.1.0"
 description = "Close LimitLion"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[tool:pytest]
-testpaths=tests
-


### PR DESCRIPTION
This PR:
* removes `setup.cfg` (which was already mostly empty)
* bumps the version number
* updates the changelog in preparation for a new release