### PR TITLE
Bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: Install uv
       uses: astral-sh/setup-uv@v6
@@ -62,7 +62,7 @@ jobs:
         uv run pytest --cov=limitlion --cov-report=xml
     
     - name: Upload coverage report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-report-py${{ matrix.python-version }}-redis${{ matrix.redis-client-version }}
         path: coverage.xml


### PR DESCRIPTION
GitHub Actions runners switch their default Node runtime from Node 20 to
**Node 24 on June 16, 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
This bumps the actions that were pinned to Node 20–era versions so CI keeps
working after the switch.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v2`, `v4` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |

CI maintenance only — no application or runtime code changes.

Closes #42
